### PR TITLE
Fix CICD failure - missing pandoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         wget https://musl.cc/arm-linux-musleabihf-cross.tgz
         tar -zxf arm-linux-musleabihf-cross.tgz
         sudo cp -r arm-linux-musleabihf-cross/* /usr/
-        sudo apt-get update && apt-get install pandoc
+        sudo apt-get update && sudo apt-get install pandoc
 
     - name: Get libusb to include
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         wget https://musl.cc/arm-linux-musleabihf-cross.tgz
         tar -zxf arm-linux-musleabihf-cross.tgz
         sudo cp -r arm-linux-musleabihf-cross/* /usr/
-        apt-get update && apt-get install pandoc
+        sudo apt-get update && apt-get install pandoc
 
     - name: Get libusb to include
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         wget https://musl.cc/arm-linux-musleabihf-cross.tgz
         tar -zxf arm-linux-musleabihf-cross.tgz
         sudo cp -r arm-linux-musleabihf-cross/* /usr/
+        apt-get update && apt-get install pandoc
 
     - name: Get libusb to include
       run: |


### PR DESCRIPTION
dfu-util started failing to build due to missing pandoc.  Added it to be installed at the start of the runner.